### PR TITLE
ECS 자동화 배포 파이프라인 구현 (GitHub Actions)

### DIFF
--- a/src/main/java/org/example/basic/parkminji/unitsixteen/deploy-to-ecs.yml
+++ b/src/main/java/org/example/basic/parkminji/unitsixteen/deploy-to-ecs.yml
@@ -1,0 +1,120 @@
+name: Build and Deploy to ECS
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Build and Push Docker Image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Grant execute permission for Gradle
+        run: chmod +x ./gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew build
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-2
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and Push Docker Image
+        id: build-image
+        run: |
+          IMAGE_NAME=${{ secrets.IMAGE_NAME }}
+          IMAGE_TAG=${{ secrets.IMAGE_TAG }}
+          CONTAINER_NAME=${{ secrets.CONTAINER_NAME }}
+          ECR_REGISTRY=${{ steps.login-ecr.outputs.registry }}
+          IMAGE_URI=$ECR_REGISTRY/$IMAGE_NAME:$IMAGE_TAG
+
+          docker build -t $IMAGE_NAME .
+          docker tag $IMAGE_NAME $IMAGE_URI
+          docker push $IMAGE_URI
+
+          echo "IMAGE_URI=$IMAGE_URI" >> $GITHUB_ENV
+
+      - name: Generate ECS Task Definition file
+        run: |
+          mkdir -p build/deploy
+          echo '{' > build/deploy/task-definition.json
+          echo '  "family": "${{ secrets.TASK_FAMILY }}",' >> build/deploy/task-definition.json
+          echo '  "networkMode": "awsvpc",' >> build/deploy/task-definition.json
+          echo '  "requiresCompatibilities": ["FARGATE"],' >> build/deploy/task-definition.json
+          echo '  "cpu": "256",' >> build/deploy/task-definition.json
+          echo '  "memory": "512",' >> build/deploy/task-definition.json
+          echo '  "executionRoleArn": "${{ secrets.EXECUTION_ROLE_ARN }}",' >> build/deploy/task-definition.json
+          echo '  "containerDefinitions": [' >> build/deploy/task-definition.json
+          echo '    {' >> build/deploy/task-definition.json
+          echo '      "name": "${{ secrets.CONTAINER_NAME }}",' >> build/deploy/task-definition.json
+          echo '      "image": "${{ env.IMAGE_URI }}",' >> build/deploy/task-definition.json
+          echo '      "portMappings": [{' >> build/deploy/task-definition.json
+          echo '        "containerPort": 8080,' >> build/deploy/task-definition.json
+          echo '        "hostPort": 8080,' >> build/deploy/task-definition.json
+          echo '        "protocol": "tcp"' >> build/deploy/task-definition.json
+          echo '      }],' >> build/deploy/task-definition.json
+          echo '      "essential": true,' >> build/deploy/task-definition.json
+          echo '      "logConfiguration": {' >> build/deploy/task-definition.json
+          echo '        "logDriver": "awslogs",' >> build/deploy/task-definition.json
+          echo '        "options": {' >> build/deploy/task-definition.json
+          echo '          "awslogs-group": "/ecs/${{ secrets.TASK_FAMILY }}",' >> build/deploy/task-definition.json
+          echo '          "awslogs-region": "ap-northeast-2",' >> build/deploy/task-definition.json
+          echo '          "awslogs-stream-prefix": "ecs"' >> build/deploy/task-definition.json
+          echo '        }' >> build/deploy/task-definition.json
+          echo '      }' >> build/deploy/task-definition.json
+          echo '    }' >> build/deploy/task-definition.json
+          echo '  ]' >> build/deploy/task-definition.json
+          echo '}' >> build/deploy/task-definition.json
+
+      - name: Upload task-definition.json
+        uses: actions/upload-artifact@v4
+        with:
+          name: task-def
+          path: build/deploy/task-definition.json
+
+  deploy:
+    name: Deploy to Amazon ECS
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-2
+
+      - name: Download task definition
+        uses: actions/download-artifact@v4
+        with:
+          name: task-def
+          path: build/deploy
+
+      - name: Deploy to Amazon ECS
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        with:
+          cluster: ${{ secrets.ECS_CLUSTER }}
+          service: ${{ secrets.ECS_SERVICE }}
+          task-definition: build/deploy/task-definition.json


### PR DESCRIPTION
## 주요 내용

Spring Boot 프로젝트를 AWS ECS에 자동 배포하기 위한 GitHub Actions 기반 CI/CD 파이프라인 구축

---

## 구현 상세

### Build Job
- `gradlew build` 명령어로 애플리케이션 빌드
- Docker 이미지 빌드 및 Amazon ECR 푸시
- Task Definition JSON 파일을 `echo` 명령어로 생성

### Deploy Job
- 앞서 생성된 task-definition.json 아티팩트 다운로드
- ECS 클러스터 및 서비스에 새로운 태스크 정의로 업데이트
- Fargate 기반 서비스 무중단 배포

---

## 테스트 결과

- main 브랜치 push 시 전체 워크플로가 정상 수행됨
- ECR에 이미지가 정상 푸시됨
- ECS 서비스가 자동으로 업데이트되어 새로운 컨테이너가 실행됨

---

## 사용된 시크릿 값

| 시크릿 이름 | 설명 |
|-------------|------|
| `AWS_ACCESS_KEY_ID` | AWS 인증용 액세스 키 |
| `AWS_SECRET_ACCESS_KEY` | AWS 인증용 시크릿 키 |
| `IMAGE_NAME` | ECR 이미지 이름 |
| `IMAGE_TAG` | 이미지 태그 (예: latest) |
| `CONTAINER_NAME` | ECS 태스크의 컨테이너 이름 |
| `TASK_FAMILY` | ECS 태스크 정의 이름 |
| `EXECUTION_ROLE_ARN` | ECS 실행 역할 ARN |
| `ECS_CLUSTER` | 배포 대상 ECS 클러스터 이름 |
| `ECS_SERVICE` | 배포 대상 ECS 서비스 이름 |

---

## 기타

- `cat <<EOF` 대신 `echo` 명령어로 JSON 생성하여 YAML 파싱 문제 해결
- `aws-actions/amazon-ecs-deploy-task-definition@v1` 사용

---

## GitHub Actions 기반 자동 배포 성공 스크린샷
<img width="2880" height="1704" alt="image" src="https://github.com/user-attachments/assets/ecec0495-621a-4e2a-886e-8dfb0a47dcf8" />
